### PR TITLE
Set up Appveyor for Windows builds, fix Windows path issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # combine-loader
 [![npm version](https://img.shields.io/npm/v/combine-loader.svg)](https://www.npmjs.com/package/combine-loader)
 [![Travis CI Build Status](https://travis-ci.org/elliottsj/combine-loader.svg?branch=master)](https://travis-ci.org/elliottsj/combine-loader)
+[![Appveyor Build status](https://ci.appveyor.com/api/projects/status/i2aljhr7inuh9wrf/branch/master?svg=true)](https://ci.appveyor.com/project/elliottsj/combine-loader/branch/master)
 
 webpack loader to combine results from multiple loaders into one object
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+environment:
+  matrix:
+    - nodejs_version: "6"
+    - nodejs_version: "5"
+    - nodejs_version: "4"
+
+cache:
+  - node_modules
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm prune
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+# Disable MSBuild
+build: off

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ module.exports.pitch = function (remainingRequest) {
     const loader = Array.isArray(loaders[key])
       ? loaders[key].join('!')
       : loaders[key];
-    return `"${key}": require("-!${loader}!${remainingRequest}")`;
+    const request = loaderUtils.stringifyRequest(this, `-!${loader}!${remainingRequest}`);
+    return `"${key}": require(${request})`;
   });
   return `module.exports = {${keysValues.join(',')}}`;
 };


### PR DESCRIPTION
Now using `loaderUtils.stringifyRequest` to generate `require` statements (which I should have been doing anyway); appears to work on Windows now.

Closes #1 